### PR TITLE
[Resolved issue #31]

### DIFF
--- a/client/src/context/index.jsx
+++ b/client/src/context/index.jsx
@@ -1,99 +1,114 @@
-import React, { useContext, createContext } from 'react';
+import React, { useContext, createContext } from "react";
 
-import { useAddress, useContract, useMetamask, useContractWrite } from '@thirdweb-dev/react';
-import { ethers } from 'ethers';
-import { EditionMetadataWithOwnerOutputSchema } from '@thirdweb-dev/sdk';
+import {
+	useAddress,
+	useContract,
+	useMetamask,
+	useContractWrite,
+} from "@thirdweb-dev/react";
+import { ethers } from "ethers";
+import { EditionMetadataWithOwnerOutputSchema } from "@thirdweb-dev/sdk";
 
 const StateContext = createContext();
 
 export const StateContextProvider = ({ children }) => {
-  const { contract } = useContract('0xf59A1f8251864e1c5a6bD64020e3569be27e6AA9');
-  const { mutateAsync: createCampaign } = useContractWrite(contract, 'createCampaign');
+	const { contract } = useContract(
+		"0xf59A1f8251864e1c5a6bD64020e3569be27e6AA9"
+	);
+	const { mutateAsync: createCampaign } = useContractWrite(
+		contract,
+		"createCampaign"
+	);
 
-  const address = useAddress();
-  const connect = useMetamask();
+	const address = useAddress();
+	const connect = useMetamask();
 
-  const publishCampaign = async (form) => {
-    try {
-      const data = await createCampaign([
-        address, // owner
-        form.title, // title
-        form.description, // description
-        form.target,
-        new Date(form.deadline).getTime(), // deadline,
-        form.image
-      ])
+	const publishCampaign = async (form) => {
+		try {
+			const data = await createCampaign([
+				address, // owner
+				form.title, // title
+				form.description, // description
+				form.target,
+				new Date(form.deadline).getTime(), // deadline,
+				form.image,
+			]);
 
-      console.log("contract call success", data)
-    } catch (error) {
-      console.log("contract call failure", error)
-    }
-  }
+			console.log("contract call success", data);
+		} catch (error) {
+			console.log("contract call failure", error);
+		}
+	};
 
-  const getCampaigns = async () => {
-    const campaigns = await contract.call('getCampaigns');
+	const getCampaigns = async () => {
+		const campaigns = await contract.call("getCampaigns");
 
-    const parsedCampaings = campaigns.map((campaign, i) => ({
-      owner: campaign.owner,
-      title: campaign.title,
-      description: campaign.description,
-      target: ethers.utils.formatEther(campaign.target.toString()),
-      deadline: campaign.deadline.toNumber(),
-      amountCollected: ethers.utils.formatEther(campaign.amountCollected.toString()),
-      image: campaign.image,
-      pId: i
-    }));
+		const parsedCampaings = campaigns.map((campaign, i) => ({
+			owner: campaign.owner,
+			title: campaign.title,
+			description: campaign.description,
+			target: ethers.utils.formatEther(campaign.target.toString()),
+			deadline: campaign.deadline.toNumber(),
+			amountCollected: ethers.utils.formatEther(
+				campaign.amountCollected.toString()
+			),
+			image: campaign.image,
+			pId: i,
+		}));
 
-    return parsedCampaings;
-  }
+		return parsedCampaings;
+	};
 
-  const getUserCampaigns = async () => {
-    const allCampaigns = await getCampaigns();
+	const getUserCampaigns = async () => {
+		const allCampaigns = await getCampaigns();
 
-    const filteredCampaigns = allCampaigns.filter((campaign) => campaign.owner === address);
+		const filteredCampaigns = allCampaigns.filter(
+			(campaign) => campaign.owner === address
+		);
 
-    return filteredCampaigns;
-  }
+		return filteredCampaigns;
+	};
 
-  const donate = async (pId, amount) => {
-    const data = await contract.call('donateToCampaign', pId, { value: ethers.utils.parseEther(amount)});
+	const donate = async (pId, amount) => {
+		const data = await contract.call("donateToCampaign", pId, {
+			value: ethers.utils.parseEther(amount),
+		});
 
-    return data;
-  }
+		return data;
+	};
 
-  const getDonations = async (pId) => {
-    const donations = await contract.call('getDonators', pId);
-    const numberOfDonations = donations[0].length;
+	const getDonations = async (pId) => {
+		const donations = await contract.call("getDonators", [pId]);
+		const numberOfDonations = donations[0].length;
 
-    const parsedDonations = [];
+		const parsedDonations = [];
 
-    for(let i = 0; i < numberOfDonations; i++) {
-      parsedDonations.push({
-        donator: donations[0][i],
-        donation: ethers.utils.formatEther(donations[1][i].toString())
-      })
-    }
+		for (let i = 0; i < numberOfDonations; i++) {
+			parsedDonations.push({
+				donator: donations[0][i],
+				donation: ethers.utils.formatEther(donations[1][i].toString()),
+			});
+		}
 
-    return parsedDonations;
-  }
+		return parsedDonations;
+	};
 
-
-  return (
-    <StateContext.Provider
-      value={{ 
-        address,
-        contract,
-        connect,
-        createCampaign: publishCampaign,
-        getCampaigns,
-        getUserCampaigns,
-        donate,
-        getDonations
-      }}
-    >
-      {children}
-    </StateContext.Provider>
-  )
-}
+	return (
+		<StateContext.Provider
+			value={{
+				address,
+				contract,
+				connect,
+				createCampaign: publishCampaign,
+				getCampaigns,
+				getUserCampaigns,
+				donate,
+				getDonations,
+			}}
+		>
+			{children}
+		</StateContext.Provider>
+	);
+};
 
 export const useStateContext = () => useContext(StateContext);

--- a/client/src/context/index.jsx
+++ b/client/src/context/index.jsx
@@ -70,7 +70,7 @@ export const StateContextProvider = ({ children }) => {
 	};
 
 	const donate = async (pId, amount) => {
-		const data = await contract.call("donateToCampaign", pId, {
+		const data = await contract.call("donateToCampaign", [pId], {
 			value: ethers.utils.parseEther(amount),
 		});
 


### PR DESCRIPTION
In the latest [release](https://blog.thirdweb.com/changelog/updated-api-for-calling-smart-contract-functions/) `contract.call()` has changed the parameters to accept array instead of single param.

>The API for interacting with smart contracts via the thirdweb React & TypeScript SDKs has been updated in favor of explicitly defining function arguments and (optionally) call overrides.

>Using the contract.call function in the TypeScript SDK now looks like the following:
```
const owner = "0x...";
const operator = "0x...";
const overrides = { gasPrice: 800000 };
const res = await contract.call("approve", [owner, operator], overrides);
```
>Note that the arguments to the contract function are now passed in as an array as the second parameter to contract.call, and the overrides are passed optionally as the last parameter.
----
Also refer official [docs](https://portal.thirdweb.com/typescript/sdk.smartcontract.call)
```
const data = await contract.call(
  "myFunctionName", // Name of your function as it is on the smart contract
  // Arguments to your function, in the same order they are on your smart contract
  [
    "arg1", // e.g. Argument 1
    "arg2", // e.g. Argument 2
  ],
);
```