### PR TITLE
[BugFix - getDonators and donateToCampaign give errors #40]

### DIFF
--- a/client/src/context/index.jsx
+++ b/client/src/context/index.jsx
@@ -56,13 +56,13 @@ export const StateContextProvider = ({ children }) => {
   }
 
   const donate = async (pId, amount) => {
-    const data = await contract.call('donateToCampaign', pId, { value: ethers.utils.parseEther(amount)});
+    const data = await contract.call('donateToCampaign', [pId], { value: ethers.utils.parseEther(amount)});
 
     return data;
   }
 
   const getDonations = async (pId) => {
-    const donations = await contract.call('getDonators', pId);
+    const donations = await contract.call('getDonators', [pId]);
     const numberOfDonations = donations[0].length;
 
     const parsedDonations = [];


### PR DESCRIPTION
In the latest [release](https://blog.thirdweb.com/changelog/updated-api-for-calling-smart-contract-functions/) `contract.call()` has changed the parameters to accept array instead of single param.

>The API for interacting with smart contracts via the thirdweb React & TypeScript SDKs has been updated in favor of explicitly defining function arguments and (optionally) call overrides.

>Using the contract.call function in the TypeScript SDK now looks like the following:
```
const owner = "0x...";
const operator = "0x...";
const overrides = { gasPrice: 800000 };
const res = await contract.call("approve", [owner, operator], overrides);
```
>Note that the arguments to the contract function are now passed in as an array as the second parameter to contract.call, and the overrides are passed optionally as the last parameter.
----
Also refer official [docs](https://portal.thirdweb.com/typescript/sdk.smartcontract.call)
```
const data = await contract.call(
  "myFunctionName", // Name of your function as it is on the smart contract
  // Arguments to your function, in the same order they are on your smart contract
  [
    "arg1", // e.g. Argument 1
    "arg2", // e.g. Argument 2
  ],
);
```
