### PR TITLE
using the clientId and activeChain instead the desiredChainId

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,20 +1,20 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import { BrowserRouter as Router } from 'react-router-dom';
-import { ChainId, ThirdwebProvider } from '@thirdweb-dev/react';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { BrowserRouter as Router } from "react-router-dom";
+import { ChainId, ThirdwebProvider } from "@thirdweb-dev/react";
 
-import { StateContextProvider } from './context';
-import App from './App';
-import './index.css';
+import { StateContextProvider } from "./context";
+import App from "./App";
+import "./index.css";
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
+const root = ReactDOM.createRoot(document.getElementById("root"));
 
 root.render(
-  <ThirdwebProvider desiredChainId={ChainId.Goerli}> 
+  <ThirdwebProvider activeChain="goerli" clientId="your-thirdweb-client-id">
     <Router>
       <StateContextProvider>
         <App />
       </StateContextProvider>
     </Router>
-  </ThirdwebProvider> 
-)
+  </ThirdwebProvider>
+);


### PR DESCRIPTION
I was getting an error to fetch the contract:
```
query.ts:446 Error: Could not fetch bytecode for contract at 0x3cEeEbd92D12345678901234567890 on chain 1, double check that the address and chainId are correct.
```
And consequently got the error on creating a campaign: `error TypeError: Cannot read properties of undefined (reading 'call')`.

This merge request solves the problem using the `activeChain` and `clientId` (got at https://thirdweb.com/dashboard/settings) instead of the `desiredChainId` on <ThirdwebProvider>.